### PR TITLE
add zsh support to cli-install

### DIFF
--- a/cli-install.py
+++ b/cli-install.py
@@ -231,7 +231,7 @@ if not has_path:
   shell = os.environ["SHELL"]
   rc_file = shell_run_commands.get(shell)
   if rc_file is None:
-    sys.exit(' '.join(['Unknown shell', shell]))
+    sys.exit('Unknown shell {}'.format(shell))
   print 'Please run `. {}` before continuing!'.format(rc_file)
   has_path = (subprocess.call(['grep', '--silent', 'cadmium', os.path.expanduser(rc_file)]) == 0)
   if not has_path:

--- a/cli-install.py
+++ b/cli-install.py
@@ -224,10 +224,18 @@ for item in path:
     break
 
 if not has_path:
-  print "Please run `. ~/.profile` before continuing!"
-  has_path = (subprocess.call(['grep', '--silent', 'cadmium', os.path.expanduser('~/.profile')]) == 0)
+  shell_run_commands = {
+    '/bin/bash': '~/.profile',
+    '/bin/zsh': '~/.zshrc'
+  }
+  shell = os.environ["SHELL"]
+  rc_file = shell_run_commands.get(shell)
+  if rc_file is None:
+    sys.exit(' '.join(['Unknown shell', shell]))
+  print 'Please run `. {}` before continuing!'.format(rc_file)
+  has_path = (subprocess.call(['grep', '--silent', 'cadmium', os.path.expanduser(rc_file)]) == 0)
   if not has_path:
-    fd = open(os.path.expanduser('~/.profile'), 'a')
+    fd = open(os.path.expanduser(rc_file), 'a')
     try:
       fd.write('\nexport PATH="$PATH:'+user_dir+'/bin"\n')
       fd.flush()


### PR DESCRIPTION
To test, execute `cli-install` in `bash` and `zsh`. Use `chsh` to change shells (e.g., `chsh -s /bin/zsh`). You may also be able to execute `cli-install` without changing shells (e.g., `zsh -c "cli-install"`) , but I haven't tried it.