### PR TITLE
Fix vagrant-cadmium-up command

### DIFF
--- a/cli-install.py
+++ b/cli-install.py
@@ -211,7 +211,7 @@ if not os.path.exists(user_dir + '/bin/cli-install.py'):
   shutil.copy(sys.argv[0], user_dir + '/bin/cli-install.py')
   os.chmod(user_dir + '/bin/cli-install.py', 0755)
 
-exitCode = subprocess.call(['curl', 'https://raw2.github.com/meltmedia/cadmium/master/vagrant-cadmium-up', '-o', user_dir + '/bin/vagrant-cadmium-up'])
+exitCode = subprocess.call(['curl', '-L', 'https://raw.github.com/meltmedia/cadmium/master/vagrant-cadmium-up', '-o', user_dir + '/bin/vagrant-cadmium-up'])
 if exitCode != 0:
   print 'Failed to download vagrant-cadmium-up!'
 else:


### PR DESCRIPTION
vagrant-cadmium-up was not getting downloaded to ~/.cadmium/bin/vagrant-cadmium-up.  The content of the downloaded file was pointing to 404 page of github.

Fix:  Location for github raw file.