### PR TITLE
Use error level for redirect failures

### DIFF
--- a/servlets/src/main/java/com/meltmedia/cadmium/servlets/RedirectFilter.java
+++ b/servlets/src/main/java/com/meltmedia/cadmium/servlets/RedirectFilter.java
@@ -89,7 +89,7 @@ public class RedirectFilter implements Filter {
     } catch(Throwable t) {
       StringWriter str = new StringWriter();
       t.printStackTrace(new PrintWriter(str));
-      log.debug("Failed in redirect filter: "+str.toString(), t);
+      log.error("Failed in redirect filter: "+t.toString(), t);
       ServletException se = new ServletException(t);
       throw se;
     }


### PR DESCRIPTION
Use error logging for redirect failures

Redirect failures were not shown as the level was set to trace. Changed to catch all error level to trace. 
Note:  This class needs a lot of refactoring and the way it is logging needs to be improved. However, for now I am just making a minimal change (time constraints) so that troubleshooting issues with redirects is easier.