### PR TITLE
Fix issue with maven reflections

### DIFF
--- a/captcha/pom.xml
+++ b/captcha/pom.xml
@@ -41,8 +41,8 @@
   <build>
     <plugins>
         <plugin>
-          <groupId>org.reflections</groupId>
-          <artifactId>reflections-maven</artifactId>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -46,8 +46,8 @@
         </executions>
       </plugin>
       <plugin>
-          <groupId>org.reflections</groupId>
-          <artifactId>reflections-maven</artifactId>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/copyright/pom.xml
+++ b/copyright/pom.xml
@@ -46,8 +46,8 @@
   <build>
     <plugins>
         <plugin>
-          <groupId>org.reflections</groupId>
-          <artifactId>reflections-maven</artifactId>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -114,8 +114,8 @@
   <build>
     <plugins>
         <plugin>
-          <groupId>org.reflections</groupId>
-          <artifactId>reflections-maven</artifactId>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/deployer/pom.xml
+++ b/deployer/pom.xml
@@ -18,8 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.reflections</groupId>
-        <artifactId>reflections-maven</artifactId>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/email/pom.xml
+++ b/email/pom.xml
@@ -78,8 +78,8 @@
   <build>
     <plugins>
         <plugin>
-          <groupId>org.reflections</groupId>
-          <artifactId>reflections-maven</artifactId>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/pdf-concatenate/pom.xml
+++ b/pdf-concatenate/pom.xml
@@ -47,8 +47,8 @@
   <build>
     <plugins>
         <plugin>
-          <groupId>org.reflections</groupId>
-          <artifactId>reflections-maven</artifactId>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -95,8 +95,8 @@
   <build>
     <plugins>
         <plugin>
-          <groupId>org.reflections</groupId>
-          <artifactId>reflections-maven</artifactId>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -512,7 +512,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.2</version>
+          <version>2.5.3</version>
           <configuration>
             <tagNameFormat>v@{project.version}</tagNameFormat>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
       <dependency>
        <groupId>org.reflections</groupId>
        <artifactId>reflections</artifactId>
-       <version>0.9.10</version>
+       <version>${reflections.version}</version>
      </dependency>
      <dependency>
         <groupId>org.jboss</groupId>
@@ -492,6 +492,7 @@
     <wagonVersion>1.0</wagonVersion>
     <hibernateVersion>4.2.3.Final</hibernateVersion>
     <luceneVersion>4.3.1</luceneVersion>
+    <reflections.version>0.9.10</reflections.version>
   </properties>
 
   <build>
@@ -511,7 +512,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.4.1</version>
+          <version>2.5.2</version>
           <configuration>
             <tagNameFormat>v@{project.version}</tagNameFormat>
           </configuration>
@@ -535,22 +536,57 @@
           </dependencies>
         </plugin>
         <plugin>
-          <groupId>org.reflections</groupId>
-          <artifactId>reflections</artifactId>
-          <version>0.9.10</version>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
+          <version>1.5</version>
           <executions>
             <execution>
-            <goals>
-              <goal>reflections</goal>
-            </goals>
-            <phase>process-classes</phase>
-            <configuration>
-              <includeExclude>+com\.meltmedia\.cadmium\..*</includeExclude>
-              <scanners>TypeAnnotationsScanner,SubTypesScanner,MethodAnnotationsScanner</scanners>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+              <phase>process-classes</phase>
+              <goals>
+                <goal>execute</goal>
+              </goals>
+              <configuration>
+                <scripts>
+                  <script><![CDATA[
+                        new org.reflections.Reflections(
+                          org.reflections.util.ClasspathHelper.forPackage("com.meltmedia.cadmium"),
+                          new org.reflections.scanners.SubTypesScanner(),
+                          new org.reflections.scanners.TypeAnnotationsScanner(),
+                          new org.reflections.scanners.MethodAnnotationsScanner()
+                        ).save("${project.build.outputDirectory}/META-INF/reflections/${project.artifactId}-reflections.xml")
+                    ]]></script>
+                </scripts>
+              </configuration>
+            </execution>
+          </executions>
+          <dependencies>
+            <dependency>
+              <groupId>org.reflections</groupId>
+              <artifactId>reflections</artifactId>
+              <!-- use latest version of Reflections -->
+              <version>${reflections.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.codehaus.groovy</groupId>
+              <artifactId>groovy-all</artifactId>
+              <!-- any version of Groovy \>= 1.5.0 should work here -->
+              <version>2.4.6</version>
+              <scope>runtime</scope>
+            </dependency>
+            <dependency>
+              <groupId>javax.servlet</groupId>
+              <artifactId>servlet-api</artifactId>
+              <version>2.5</version>
+              <scope>runtime</scope>
+            </dependency>
+            <dependency>
+              <groupId>dom4j</groupId>
+              <artifactId>dom4j</artifactId>
+              <version>1.6.1</version>
+            </dependency>
+
+          </dependencies>
+        </plugin>
       <plugin>
         <groupId>com.mycila.maven-license-plugin</groupId>
         <artifactId>maven-license-plugin</artifactId>

--- a/search-suggest/pom.xml
+++ b/search-suggest/pom.xml
@@ -39,8 +39,8 @@
   <build>
     <plugins>
         <plugin>
-          <groupId>org.reflections</groupId>
-          <artifactId>reflections-maven</artifactId>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/search/pom.xml
+++ b/search/pom.xml
@@ -84,8 +84,8 @@
   <build>
     <plugins>
         <plugin>
-          <groupId>org.reflections</groupId>
-          <artifactId>reflections-maven</artifactId>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/servlets/pom.xml
+++ b/servlets/pom.xml
@@ -99,8 +99,8 @@
   <build>
     <plugins>
         <plugin>
-          <groupId>org.reflections</groupId>
-          <artifactId>reflections-maven</artifactId>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
**Problem**
Any sites including development version of cadmium will fail to deploy. Why ?  reflection manifest is missing and cadmium uses Reflections library heavily to check for annotations.  Since it could not find manifest,  annotations lookup failed resulting in jersey error: 
```
07:04:42,928 ERROR [org.apache.catalina.core.ContainerBase.[jboss.web].[gazyva-cadmium-test.cd.meltdev.com].[/]] (ServerService Thread Pool -- 147) JBWEB000284: Exception starting filter guiceFilter: com.sun.jersey.api.container.ContainerException: The ResourceConfig instance does not contain any root resource classes.
	at com.sun.jersey.server.impl.application.RootResourceUriRules.<init>(RootResourceUriRules.java:99) [jersey-server-1.12.jar:1.12]
	at com.sun.jersey.server.impl.application.WebApplicationImpl._initiate(WebApplicationImpl.java:1308) [jersey-server-1.12.jar:1.12]
	at com.sun.jersey.server.impl.application.WebApplicationImpl.access$700(WebApplicationImpl.java:171) [jersey-server-1.12.jar:1.12]
	at com.sun.jersey.server.impl.application.WebApplicationImpl$13.f(WebApplicationImpl.java:777) [jersey-server-1.12.jar:1.12]
	at com.sun.jersey.server.impl.application.WebApplicationImpl$13.f(WebApplicationImpl.java:773) [jersey-server-1.12.jar:1.12]
	at com.sun.jersey.spi.inject.Errors.processWithErrors(Errors.java:193) [jersey-core-1.12.jar:1.12]
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiate(WebApplicationImpl.java:773) [jersey-server-1.12.jar:1.12]
	at com.meltmedia.cadmium.servlets.guice.SystemGuiceContainer.initiate(SystemGuiceContainer.java:48) [cadmium-servlets-1.0.2-SNAPSHOT.jar:]
	at com.sun.jersey.spi.container.servlet.ServletContainer$InternalWebComponent.initiate(ServletContainer.java:318) [jersey-servlet-1.12.jar:1.12]
	at com.sun.jersey.spi.container.servlet.WebComponent.load(WebComponent.java:607) [jersey-servlet-1.12.jar:1.12]
	at com.sun.jersey.spi.container.servlet.WebComponent.init(WebComponent.java:208) [jersey-servlet-1.12.jar:1.12]
	at com.sun.jersey.spi.container.servlet.ServletContainer.init(ServletContainer.java:373) [jersey-servlet-1.12.jar:1.12]
	at com.sun.jersey.spi.container.servlet.ServletContainer.init(ServletContainer.java:556) [jersey-servlet-1.12.jar:1.12]
	at javax.servlet.GenericServlet.init(GenericServlet.java:242) [jboss-servlet-api_3.0_spec-1.0.2.Final-redhat-1.jar:1.0.2.Final-redhat-1]
	at com.google.inject.servlet.ServletDefinition.init(ServletDefinition.java:117) [guice-servlet-3.0.jar:]
	at com.google.inject.servlet.ManagedServletPipeline.init(ManagedServletPipeline.java:82) [guice-servlet-3.0.jar:]
	at com.google.inject.servlet.ManagedFilterPipeline.initPipeline(ManagedFilterPipeline.java:102) [guice-servlet-3.0.jar:]
	at com.google.inject.servlet.GuiceFilter.init(GuiceFilter.java:172) [guice-servlet-3.0.jar:]
	at org.apache.catalina.core.ApplicationFilterConfig.getFilter(ApplicationFilterConfig.java:416) [jbossweb-7.2.0.Final-redhat-1.jar:7.2.0.Final-redhat-1]
	at org.apache.catalina.core.StandardContext.filterStart(StandardContext.java:3225) [jbossweb-7.2.0.Final-redhat-1.jar:7.2.0.Final-redhat-1]
	at org.apache.catalina.core.StandardContext.start(StandardContext.java:3791) [jbossweb-7.2.0.Final-redhat-1.jar:7.2.0.Final-redhat-1]
	at org.jboss.as.web.deployment.WebDeploymentService.doStart(WebDeploymentService.java:156) [jboss-as-web-7.2.0.Final-redhat-8.jar:7.2.0.Final-redhat-8]
	at org.jboss.as.web.deployment.WebDeploymentService.access$000(WebDeploymentService.java:60) [jboss-as-web-7.2.0.Final-redhat-8.jar:7.2.0.Final-redhat-8]
	at org.jboss.as.web.deployment.WebDeploymentService$1.run(WebDeploymentService.java:93) [jboss-as-web-7.2.0.Final-redhat-8.jar:7.2.0.Final-redhat-8]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471) [rt.jar:1.6.0_30]
	at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:334) [rt.jar:1.6.0_30]
	at java.util.concurrent.FutureTask.run(FutureTask.java:166) [rt.jar:1.6.0_30]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1146) [rt.jar:1.6.0_30]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615) [rt.jar:1.6.0_30]
	at java.lang.Thread.run(Thread.java:701) [rt.jar:1.6.0_30]
	at org.jboss.threads.JBossThread.run(JBossThread.java:122)
```
**Fix**
Fix issue with maven reflections caused by commit https://github.com/meltmedia/cadmium/commit/66a270a3acec9209a770717ea74f95f2f5f31439



Since the plugin is deprecated, I have replaced it via gmaven-plus as per recommendation by the author: https://github.com/ronmamo/reflections-maven.

The bamboo build is activated and is passing.

Verified fix using Gazyva site (cadmium-test branch). 