### PR TITLE
Enhance error logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ target
 .settings
 .classpath
 .DS_Store
+
+.idea/
+*.iml
+*.versionsBackup

--- a/captcha/pom.xml
+++ b/captcha/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>cadmium-captcha</artifactId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-cli</artifactId>

--- a/copyright/pom.xml
+++ b/copyright/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>cadmium-copyright</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-core</artifactId>

--- a/core/src/main/java/com/meltmedia/cadmium/core/commands/ContentUpdateRequest.java
+++ b/core/src/main/java/com/meltmedia/cadmium/core/commands/ContentUpdateRequest.java
@@ -30,6 +30,7 @@ public class ContentUpdateRequest extends AbstractMessageBean {
   protected String uuid;
   protected String comment;
   protected boolean revertable;
+  protected String failureReason;
   
   public GitLocation getContentLocation() {
     return contentLocation;
@@ -67,6 +68,10 @@ public class ContentUpdateRequest extends AbstractMessageBean {
   public void setRevertable(boolean revertable) {
     this.revertable = revertable;
   }
-
-
+  public String getFailureReason() {
+    return failureReason;
+  }
+  public void setFailureReason(String failureReason) {
+    this.failureReason = failureReason;
+  }
 }

--- a/core/src/main/java/com/meltmedia/cadmium/core/commands/UpdateFailedCommandAction.java
+++ b/core/src/main/java/com/meltmedia/cadmium/core/commands/UpdateFailedCommandAction.java
@@ -63,7 +63,7 @@ public class UpdateFailedCommandAction implements CommandAction<ContentUpdateReq
             emptyStringIfNull(body.getOpenId()),
             "",
             body.getUuid(),
-            FAILED_LOG_MESSAGE,
+            body.getFailureReason(),
             false, false, true, true);
       }
     }

--- a/core/src/main/java/com/meltmedia/cadmium/core/meta/SiteConfigProcessor.java
+++ b/core/src/main/java/com/meltmedia/cadmium/core/meta/SiteConfigProcessor.java
@@ -49,13 +49,9 @@ public class SiteConfigProcessor {
             processor.processFromDirectory(metaDir);
           } catch(IOException e) {
             throw e;
-          } catch(Exception e){
-            log.error("Failed to process config", e);
-            failed = true;
+          } catch(Exception e) {
+            throw e;
           }
-        }
-        if(failed) {
-          throw new Exception("One or more configs failed! See log for details.");
         }
       } else {
         log.warn("No config processors exist in this context");
@@ -70,5 +66,4 @@ public class SiteConfigProcessor {
       }
     }
   }
-  
 }

--- a/core/src/main/java/com/meltmedia/cadmium/core/meta/SiteConfigProcessor.java
+++ b/core/src/main/java/com/meltmedia/cadmium/core/meta/SiteConfigProcessor.java
@@ -41,17 +41,10 @@ public class SiteConfigProcessor {
     String metaDir = new File(contentDirectory, "META-INF").getAbsoluteFile().getAbsolutePath();
     if(metaDir != null) {
       if(processors != null) {
-        boolean failed = false;
         log.info("Running {} processor[s] for {} directory", processors.size(), metaDir);
         for(ConfigProcessor processor : processors) {
-          try {
-            log.info("Running {}", processor.getClass().getName());
-            processor.processFromDirectory(metaDir);
-          } catch(IOException e) {
-            throw e;
-          } catch(Exception e) {
-            throw e;
-          }
+          log.info("Running {}", processor.getClass().getName());
+          processor.processFromDirectory(metaDir);
         }
       } else {
         log.warn("No config processors exist in this context");

--- a/core/src/main/java/com/meltmedia/cadmium/core/worker/CleanUpTask.java
+++ b/core/src/main/java/com/meltmedia/cadmium/core/worker/CleanUpTask.java
@@ -20,6 +20,9 @@ import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
+import com.meltmedia.cadmium.core.commands.UpdateFailedCommandAction;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +55,11 @@ public class CleanUpTask implements Callable<Boolean> {
           throw new Exception("Previous task failed");
         }
       } catch(Exception e) {
-        log.warn("Work failed!", e);
+        Throwable throwable = ExceptionUtils.getRootCause(e);
+        log.error("Work failed!", throwable);
+
+        String failureReason = StringUtils.isEmpty(throwable.getMessage()) ? UpdateFailedCommandAction.FAILED_LOG_MESSAGE : throwable.getMessage();
+        contentUpdateBody.setFailureReason(throwable.getClass().getSimpleName()+ ": " + failureReason);
         listener.workFailed(contentUpdateBody);
         return false;
       }

--- a/deployer/pom.xml
+++ b/deployer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>cadmium-deployer</artifactId>
   <packaging>war</packaging>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-deployment-parent</artifactId>

--- a/deployment/provisioning/pom.xml
+++ b/deployment/provisioning/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium-deployment-parent</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-deployment</artifactId>

--- a/email/pom.xml
+++ b/email/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>cadmium-email</artifactId>

--- a/executable-war/pom.xml
+++ b/executable-war/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-executable-war</artifactId>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <name>cadmium :: Maven</name>

--- a/pdf-concatenate/pom.xml
+++ b/pdf-concatenate/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-pdf-concatenate</artifactId>

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-persistence</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.meltmedia.cadmium</groupId>
   <artifactId>cadmium</artifactId>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>cadmium :: Parent POM</name>

--- a/search-suggest/pom.xml
+++ b/search-suggest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-search-suggest</artifactId>

--- a/search/pom.xml
+++ b/search/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-search</artifactId>

--- a/servlets/pom.xml
+++ b/servlets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>cadmium</artifactId>
     <groupId>com.meltmedia.cadmium</groupId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-servlets</artifactId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>cadmium-war</artifactId>
   <packaging>war</packaging>


### PR DESCRIPTION
Ticket: [CADMIUM-258](https://jira.meltdev.com/browse/CADMIUM-258)

### The Problem
After a content deploy fails, there is a generic reason given that doesn't help troubleshoot the problem. Furthermore, nothing helpful is put into the console logs or history log.

### The Fix
Exception messages are now passed up the execution chain and passed in the ContentUpdateRequest upon a content update failure. Those exception messages now get logged in the history.json.