### PR TITLE
Initialize config prior to content

### DIFF
--- a/servlets/src/main/java/com/meltmedia/cadmium/servlets/guice/Initializor.java
+++ b/servlets/src/main/java/com/meltmedia/cadmium/servlets/guice/Initializor.java
@@ -39,9 +39,9 @@ public class Initializor implements Closeable {
     log.debug("Submitting initialization tasks.");
     this.pool = Executors.newSingleThreadExecutor();
     
-    pool.submit(task2.setExecutor(pool).setFuture(pool.submit(task)));
-    
     pool.submit(task4.setExecutor(pool).setFuture(pool.submit(task3)));
+    
+    pool.submit(task2.setExecutor(pool).setFuture(pool.submit(task)));
   }
 
   @Override

--- a/servlets/src/main/java/com/meltmedia/cadmium/servlets/guice/Initializor.java
+++ b/servlets/src/main/java/com/meltmedia/cadmium/servlets/guice/Initializor.java
@@ -32,7 +32,7 @@ import java.util.concurrent.Executors;
 @Singleton
 public class Initializor implements Closeable {
   private final Logger log = LoggerFactory.getLogger(getClass());
-  private ExecutorService pool = null;
+  ExecutorService pool = null;
   
   @Inject
   public Initializor(InitializeTask task, CheckInitializedTask task2, ConfigInitializeTask task3, CheckConfigInitializedTask task4) {

--- a/servlets/src/test/java/com/meltmedia/cadmium/servlets/guice/InitializorTest.java
+++ b/servlets/src/test/java/com/meltmedia/cadmium/servlets/guice/InitializorTest.java
@@ -1,0 +1,62 @@
+package com.meltmedia.cadmium.servlets.guice;
+
+import com.meltmedia.cadmium.core.git.GitService;
+import com.meltmedia.cadmium.core.worker.CheckConfigInitializedTask;
+import com.meltmedia.cadmium.core.worker.CheckInitializedTask;
+import com.meltmedia.cadmium.core.worker.ConfigInitializeTask;
+import com.meltmedia.cadmium.core.worker.InitializeTask;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Test for {@link Initializor}
+ */
+public class InitializorTest {
+
+  InitializeTask initTask;
+  CheckInitializedTask checkInitTask;
+  ConfigInitializeTask configInitTask;
+  CheckConfigInitializedTask checkConfigInitTask;
+
+  @Before
+  public void setUp() {
+    initTask = mock(InitializeTask.class);
+    checkInitTask = mock(CheckInitializedTask.class);
+    configInitTask = mock(ConfigInitializeTask.class);
+    checkConfigInitTask = mock(CheckConfigInitializedTask.class);
+
+    when(checkInitTask.setFuture(any(Future.class))).thenReturn(checkInitTask);
+    when(checkInitTask.setExecutor(any(ExecutorService.class))).thenReturn(checkInitTask);
+    when(checkConfigInitTask.setFuture(any(Future.class))).thenReturn(checkConfigInitTask);
+    when(checkConfigInitTask.setExecutor(any(ExecutorService.class))).thenReturn(checkConfigInitTask);
+
+  }
+
+  @Test
+  public void shouldExecuteConfigTaskPriorToContent() throws Exception {
+    //Given: Tasks that needs to be executed in order
+    InOrder inOrder = inOrder(initTask, checkInitTask, configInitTask, checkConfigInitTask);
+
+    //When: I create new initializor and execute tasks
+    Initializor initializor = new Initializor(initTask, checkInitTask, configInitTask, checkConfigInitTask);
+    initializor.pool.shutdown();
+    initializor.pool.awaitTermination(5, TimeUnit.SECONDS);
+
+    //Then: Tasks are executed in order: initTask, checkInitTask, configInitTask, checkConfigInitTask
+    inOrder.verify(configInitTask).call();
+    inOrder.verify(checkConfigInitTask).call();
+    inOrder.verify(initTask).call();
+    inOrder.verify(checkInitTask).call();
+
+  }
+
+}


### PR DESCRIPTION
[CADMIUM-269](https://jira.meltdev.com/browse/CADMIUM-269)
Initialize config prior to content so that operations like vault that does pre-processing of content has updated config prior to executing the content update.

**What issue are we facing ?**
If the content cache is removed, any site that relies on imsafe fails to fetch safety during startup as default config relies on gvault and config update happens after content.

**Steps to verify**
Deploy any site (with content folders removed).  During the deploy process, you should see config folder is checked our before content in content folder.