### PR TITLE
Add better error handling when content / config update fails

### DIFF
--- a/cli/src/main/java/com/meltmedia/cadmium/cli/UpdateCommand.java
+++ b/cli/src/main/java/com/meltmedia/cadmium/cli/UpdateCommand.java
@@ -138,8 +138,8 @@ public class UpdateCommand extends AbstractAuthorizedOnly implements CliCommand 
 
 		} 
 		catch (Exception e) {
-
-			System.err.println("Failed to updated site [" + siteUrl  + "] to repo [" + repo + "] branch [" + branch  + "] and revision [" + revision  + "].");
+			System.err.println("Failed to updated site [" + siteUrl  + "] to repo [" + repo + "] branch [" + branch  + "] " +
+          "and revision [" + revision  + "]. "+e.getMessage());
 		}
 
 	}

--- a/cli/src/main/java/com/meltmedia/cadmium/cli/UpdateConfigCommand.java
+++ b/cli/src/main/java/com/meltmedia/cadmium/cli/UpdateConfigCommand.java
@@ -128,7 +128,8 @@ public class UpdateConfigCommand extends AbstractAuthorizedOnly implements CliCo
     } 
     catch (Exception e) {
 
-      System.err.println("Failed to updated site [" + siteUrl  + "] to repo [" + repo + "] branch [" + branch  + "] and revision [" + revision  + "].");
+      System.err.println("Failed to updated site [" + siteUrl  + "] to repo [" + repo + "] branch [" + branch  + "] " +
+          "and revision [" + revision  + "]. "+e.getMessage());
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>1.9.0</version>
+        <version>1.10.19</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -461,6 +461,20 @@
         <version>1.4</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito</artifactId>
+        <version>${powermock.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <version>${powermock.version}</version>
+        <scope>test</scope>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 
@@ -493,6 +507,7 @@
     <hibernateVersion>4.2.3.Final</hibernateVersion>
     <luceneVersion>4.3.1</luceneVersion>
     <reflections.version>0.9.10</reflections.version>
+    <powermock.version>1.6.5</powermock.version>
   </properties>
 
   <build>

--- a/servlets/pom.xml
+++ b/servlets/pom.xml
@@ -95,6 +95,14 @@
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-json</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/servlets/src/main/java/com/meltmedia/cadmium/servlets/jersey/HistoryService.java
+++ b/servlets/src/main/java/com/meltmedia/cadmium/servlets/jersey/HistoryService.java
@@ -20,15 +20,12 @@ import java.util.Date;
 import java.util.List;
 
 import javax.inject.Inject;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 
+import com.meltmedia.cadmium.servlets.jersey.error.ErrorUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,6 +57,9 @@ public class HistoryService extends AuthorizationService {
   
   @Inject
   private MembershipTracker membershipTracker;
+
+  @Context
+  UriInfo uriInfo;
 
   @GET
   @Produces("application/json")
@@ -109,7 +109,7 @@ public class HistoryService extends AuthorizationService {
     if(entry != null && entry.isFinished()) {
       found = true;
       if(entry.isFailed()) {
-        throw new Exception(entry.getComment());
+        ErrorUtil.throwInternalError(entry.getComment(), uriInfo);
       }
     }
     return found+"";

--- a/servlets/src/main/java/com/meltmedia/cadmium/servlets/jersey/error/ErrorUtil.java
+++ b/servlets/src/main/java/com/meltmedia/cadmium/servlets/jersey/error/ErrorUtil.java
@@ -1,0 +1,83 @@
+package com.meltmedia.cadmium.servlets.jersey.error;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * Utility class for creating error response.
+ */
+public class ErrorUtil {
+
+  /**
+   * Enum representing different application error codes.
+   */
+  public enum ErrorCode {
+    INTERNAL("INTERNAL");
+    String code;
+    ErrorCode(String code) {
+      this.code=code;
+    }
+    public String getCode() {
+      return code;
+    }
+  }
+
+  /**
+   * Gets the cadmium environment
+   * @return <code>String</code> representing cadmium environment
+   */
+  public static String getEnvironment() {
+    return System.getProperty("com.meltmedia.cadmium.environment", "local");
+  }
+
+  /**
+   * Checks if given cadmium environment is production
+   * @return
+   */
+  public static boolean isProduction() {
+    return getEnvironment().toLowerCase().contains("prod");
+  }
+
+  /**
+   * Creates Jersey response corresponding to internal error
+   * @param throwable {@link Throwable} object representing an error
+   * @param uriInfo {@link UriInfo} object used for forming links
+   * @return {@link Response} Jersey response object containing JSON representation of the error.
+   */
+  public static Response internalError(Throwable throwable, UriInfo uriInfo) {
+    GenericError error =  new GenericError(
+        ExceptionUtils.getRootCauseMessage(throwable),
+        ErrorCode.INTERNAL.getCode(),
+        uriInfo.getAbsolutePath().toString());
+
+    if (!isProduction()) {
+      error.setStack(ExceptionUtils.getStackTrace(throwable));
+    }
+
+    return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+        .type(MediaType.APPLICATION_JSON_TYPE)
+        .entity(error)
+        .build();
+  }
+
+  /**
+   * Wraps the error as {@link WebApplicationException} with error mapped as JSON Response
+   * @param message {@link String} representing internal error
+   * @param uriInfo {@link UriInfo} used for forming link
+   */
+  public static void throwInternalError(String message, UriInfo uriInfo) {
+    GenericError error =  new GenericError(
+        message,
+        ErrorCode.INTERNAL.getCode(),
+        uriInfo.getAbsolutePath().toString());
+
+    throw new WebApplicationException(Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+        .type(MediaType.APPLICATION_JSON_TYPE)
+        .entity(error)
+        .build());
+  }
+}

--- a/servlets/src/main/java/com/meltmedia/cadmium/servlets/jersey/error/GenericError.java
+++ b/servlets/src/main/java/com/meltmedia/cadmium/servlets/jersey/error/GenericError.java
@@ -1,0 +1,109 @@
+package com.meltmedia.cadmium.servlets.jersey.error;
+
+/**
+ * Model representing generic error message for API
+ */
+public class GenericError {
+
+  /**
+   * Message associated with error
+   */
+  String message;
+
+  /**
+   * Generic code associated with error
+   */
+  String code;
+
+  /**
+   * Option error stacktrace
+   */
+  String stack;
+
+  /**
+   * Resource path that resulted in this error
+   */
+  String path;
+
+  /**
+   * Default constructor
+   */
+  public GenericError() {}
+
+  /**
+   * Constructor using most commonly using fields (message, code, path)
+   * @param message
+   * @param code
+   * @param path
+   */
+  public GenericError(String message, String code, String path) {
+    this.message = message;
+    this.code = code;
+    this.path = path;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public void setCode(String code) {
+    this.code = code;
+  }
+
+  public String getStack() {
+    return stack;
+  }
+
+  public void setStack(String stack) {
+    this.stack = stack;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  @Override
+  public String toString() {
+    return "GenericError{" +
+        "message='" + message + '\'' +
+        ", code='" + code + '\'' +
+        ", stack='" + stack + '\'' +
+        ", path='" + path + '\'' +
+        '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof GenericError)) return false;
+
+    GenericError that = (GenericError) o;
+
+    if (getMessage() != null ? !getMessage().equals(that.getMessage()) : that.getMessage() != null) return false;
+    if (getCode() != null ? !getCode().equals(that.getCode()) : that.getCode() != null) return false;
+    if (getStack() != null ? !getStack().equals(that.getStack()) : that.getStack() != null) return false;
+    return getPath() != null ? getPath().equals(that.getPath()) : that.getPath() == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = getMessage() != null ? getMessage().hashCode() : 0;
+    result = 31 * result + (getCode() != null ? getCode().hashCode() : 0);
+    result = 31 * result + (getStack() != null ? getStack().hashCode() : 0);
+    result = 31 * result + (getPath() != null ? getPath().hashCode() : 0);
+    return result;
+  }
+}

--- a/servlets/src/test/java/com/meltmedia/cadmium/servlets/jersey/ErrorUtilTest.java
+++ b/servlets/src/test/java/com/meltmedia/cadmium/servlets/jersey/ErrorUtilTest.java
@@ -1,0 +1,92 @@
+package com.meltmedia.cadmium.servlets.jersey;
+
+import com.meltmedia.cadmium.servlets.jersey.error.ErrorUtil;
+import com.meltmedia.cadmium.servlets.jersey.error.GenericError;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.powermock.api.mockito.PowerMockito.*;
+
+/**
+ * Test for {@link com.meltmedia.cadmium.servlets.jersey.error.ErrorUtil}
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest( { GenericError.class, System.class })
+public class ErrorUtilTest {
+
+  UriInfo uriInfo = mock(UriInfo.class);
+
+  @Before
+  public void setup() throws URISyntaxException {
+    when(uriInfo.getAbsolutePath()).thenReturn(new URI("/mockpath"));
+  }
+
+
+
+  @Test
+  public void shouldReturnFalseWhenEnvironmentIsProduction() {
+    assertThat("Environment should not be production", ErrorUtil.isProduction(), equalTo(false));
+  }
+
+  @Test
+  public void shouldReturnTrueWhenEnvironmentIsProduction() {
+    mockStatic(System.class);
+
+    when(System.getProperty(Mockito.anyString())).thenReturn("production");
+    assertThat("Environment should not be production", ErrorUtil.isProduction(), equalTo(false));
+  }
+
+  @Test
+  public void shouldReturnErrorResponseForGivenException() throws URISyntaxException {
+
+    //When: I invoke internalError
+    Response response = ErrorUtil.internalError(new Exception("Mock"), uriInfo);
+
+    //Then: Expected response is returned
+    final GenericError error = (GenericError) response.getEntity();
+    assertThat("Status code is set to 500", response.getStatus(),
+        equalTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()));
+    assertThat("Expected error message is set", error.getMessage(), equalTo("Exception: Mock"));
+    assertThat("Expected path is set", error.getPath(), equalTo("/mockpath"));
+    assertThat("Expected code is set", error.getCode(), equalTo(ErrorUtil.ErrorCode.INTERNAL.getCode()));
+
+  }
+
+  @Test
+  public void shouldThrowWebApplicationExceptionWhenThereIsInternalErrorDuringProcessing() throws URISyntaxException {
+
+    //When: I invoke internalError
+    WebApplicationException waex = null;
+    try {
+      ErrorUtil.throwInternalError("MockError", uriInfo);
+    } catch (WebApplicationException exc) {
+      waex = exc;
+    }
+
+    //Then: Expected response is returned
+    assertThat("WebApplicationException was thrown", waex, CoreMatchers.<WebApplicationException>notNullValue());
+    final Response response = waex.getResponse();
+    final GenericError error = (GenericError) response.getEntity();
+    assertThat("Status code is set to 500", response.getStatus(),
+        equalTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()));
+    assertThat("Expected error message is set", error.getMessage(), equalTo("MockError"));
+    assertThat("Expected path is set", error.getPath(), equalTo("/mockpath"));
+    assertThat("Expected code is set", error.getCode(), equalTo(ErrorUtil.ErrorCode.INTERNAL.getCode()));
+
+  }
+
+}


### PR DESCRIPTION
**What is changing?**
- Add better error handling for history service so that when content / config update fails,  JSON error is sent back to the client instead of raw html error.
- Modify cadmium cli to print the error message when config / content update fails.

**How to verify fix ?**
- Ensure that cadmium tests pass
```
mvn clean install
```
- Copy latest cadmium-cli to ~/.cadmium directory
```
mv cli/target/cadmium-cli-*.jar ~/.cadmium/cadmium-cli.jar
```
- Modify any of the cadmium sites (that uses safety) , and update cadmium version to 1.1.0-SNAPSHOT.
- Deploy the  cadmium site (using cadmium provisioner or using cadmium admin)
- Modify the content folder, and point to fake safety for the site.
- Use cadmium cli to pull in latest content
```
cadmium update -m 'test safety'  cadmium.local
```
This should fail to update the safety and will print out error message:
```
etting status of [http://cadmium.local]
Failed to updated site [http://cadmium.local] to repo [null] branch [null] and revision [null]. {"message":"SafetyException: There were problems with the following safeties: bb4db3f8-1100-4938-8d96-f29d747474b5-not.","code":"INTERNAL","stack":null,"path":"http://cadmium.local/system/history/e4d5b28a-06fb-8c7b-86ba-06c81a02f220/1466226409912"}
```