### PR TITLE
Update File Request Logging Level

### DIFF
--- a/servlets/src/main/java/com/meltmedia/cadmium/servlets/BasicFileServlet.java
+++ b/servlets/src/main/java/com/meltmedia/cadmium/servlets/BasicFileServlet.java
@@ -322,6 +322,11 @@ public class BasicFileServlet
     
     context.range = context.request.getHeader(RANGE_HEADER);
     
+    /*
+      Tries to parse the If-Range header as a date. Will throw an
+      IllegalArgumentException if the value cannot be parsed as a
+      date.
+     */
     try {
       context.inRangeDate = context.request.getDateHeader(IF_RANGE_HEADER);
       if(context.inRangeDate != -1 && context.inRangeDate >= lastUpdated) {
@@ -331,7 +336,11 @@ public class BasicFileServlet
         }
       }
     } catch(IllegalArgumentException iae) {
-      logger.error("Invalid range serving request: "+context.path, iae);
+      /*
+        Will read the If-Range header as an ETag. We've
+        mostly seen weak ETags.
+      */
+      logger.debug("The If-Range header for " + context.path + " could not be parsed as a date. Parsing as an ETag.");
       context.inRangeETag = context.request.getHeader(IF_RANGE_HEADER);
       if(context.inRangeETag != null && validateStrong(context.inRangeETag, context.eTag ) ) {
         if(!parseRanges(context)){


### PR DESCRIPTION
### The Problem
Loggly was being filled with errors about an `Invalid range serving request`. Diving a little a deeper, it was found that while a file request was being processed, the `If-Range` header was sometimes being populated with an invalid date. When it would try to parse the header as a date, an `IllegalArgumentException` would be thrown, logged as an error, and then would parse the header as an ETag.

### The Solution
The thrown exception is acceptable behavior, and should therefore not be logged as an error. I have changed the logging level to debug and re-written the message to be more meaningful.