### PR TITLE
Fix Redirects

### DIFF
--- a/captcha/pom.xml
+++ b/captcha/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
   
   <artifactId>cadmium-captcha</artifactId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-cli</artifactId>

--- a/copyright/pom.xml
+++ b/copyright/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
   
   <artifactId>cadmium-copyright</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-core</artifactId>

--- a/deployer/pom.xml
+++ b/deployer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
   <artifactId>cadmium-deployer</artifactId>
   <packaging>war</packaging>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-deployment-parent</artifactId>

--- a/deployment/provisioning/pom.xml
+++ b/deployment/provisioning/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium-deployment-parent</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-deployment</artifactId>

--- a/email/pom.xml
+++ b/email/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
   
   <artifactId>cadmium-email</artifactId>

--- a/executable-war/pom.xml
+++ b/executable-war/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-executable-war</artifactId>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
 
   <name>cadmium :: Maven</name>

--- a/pdf-concatenate/pom.xml
+++ b/pdf-concatenate/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-pdf-concatenate</artifactId>

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-persistence</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.meltmedia.cadmium</groupId>
   <artifactId>cadmium</artifactId>
-  <version>1.1.2-SNAPSHOT</version>
+  <version>1.1.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>cadmium :: Parent POM</name>

--- a/search-suggest/pom.xml
+++ b/search-suggest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-search-suggest</artifactId>

--- a/search/pom.xml
+++ b/search/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-search</artifactId>

--- a/servlets/pom.xml
+++ b/servlets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>cadmium</artifactId>
     <groupId>com.meltmedia.cadmium</groupId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-servlets</artifactId>

--- a/servlets/src/main/java/com/meltmedia/cadmium/servlets/RedirectFilter.java
+++ b/servlets/src/main/java/com/meltmedia/cadmium/servlets/RedirectFilter.java
@@ -57,10 +57,14 @@ public class RedirectFilter implements Filter {
         redir = redirect.requestMatches(path, queryString);
         if(redir != null) {
           String redirectTo = redir.getUrlSubstituted();
-          if(StringUtils.isNotBlank(queryString) && !redirectTo.contains("?")) {
-          	
-          	redirectTo += "?" + queryString;
-          	log.debug("adding query string to redirect path: {}", redirectTo);
+          if(StringUtils.isNotBlank(queryString)) {
+            if(!redirectTo.contains("?")) {
+              redirectTo += "?" + queryString;
+              log.debug("adding query string to redirect path: {}", redirectTo);
+            } else {
+              redirectTo += "&" + queryString;
+              log.debug("adding query string: {} to redirect path: {}", queryString, redirectTo);
+            }
           }
           response.setHeader("Location", redirectTo);
           response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);

--- a/servlets/src/test/java/com/meltmedia/cadmium/servlets/RedirectFilterTest.java
+++ b/servlets/src/test/java/com/meltmedia/cadmium/servlets/RedirectFilterTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletOutputStream;
-import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import static org.mockito.Mockito.mock;
@@ -29,17 +29,17 @@ public class RedirectFilterTest {
     @Test
     public void testDoFilter() throws Exception {
         RedirectFilter filter = new RedirectFilter();
-
         HttpServletResponse response = mock(HttpServletResponse.class);
         ServletOutputStream out = mock(ServletOutputStream.class);
         when(response.getOutputStream()).thenReturn(out);
         FilterChain chain = mock(FilterChain.class);
 
-        ServletRequest request; //add each inputRequest
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURL().thenReturn(new StringBuffer(inputRequests[0])));
 
         filter.doFilter(request, response,chain);
 
         verify(response).setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
-        verify(response).setHeader("Location", expectedResponses);
+        verify(response).setHeader("Location", expectedResponses[0]);
     }
 }

--- a/servlets/src/test/java/com/meltmedia/cadmium/servlets/RedirectFilterTest.java
+++ b/servlets/src/test/java/com/meltmedia/cadmium/servlets/RedirectFilterTest.java
@@ -1,5 +1,7 @@
 package com.meltmedia.cadmium.servlets;
 
+import com.meltmedia.cadmium.core.meta.Redirect;
+import com.meltmedia.cadmium.core.meta.RedirectConfigProcessor;
 import org.junit.Test;
 
 import javax.servlet.FilterChain;
@@ -7,6 +9,10 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -14,34 +20,41 @@ import static org.mockito.Mockito.when;
 
 public class RedirectFilterTest {
 
-    private String[] inputRequests = {
-        "http://domain.com/some/path/with?params=true",
-        "http://domain.com/some/path/without/",
-        "http://domain.com/some/path?extra=1"
+    private String[][] pathRedirectPairs = new String[][] {
+        {"/path/to/redirected","/redirected"},
+        {"/path/to/params", "/redirected/with?params=true"},
+        {"/anypath/*", "/redirected/regex/path"}
     };
 
-    private String[] expectedResponses = {
-        "http://domain.com/redirected/path?params=true",
-        "http://domain.com/redirected/path/with?params=true",
-        "http://domain.com/redirected/path/with?params=true&extra=1"
+    private String[][] inputResponsePairs = new String[][] {
+        {"/path/to/redirected",null,"/redirected"},
+        {"/path/to/redirected","params=true","/redirected?params=true"},
+        {"/path/to/params",null,"/redirected/with?params=true"},
+        {"/path/to/params","zero=100","/redirected/with?params=true&zero=100"},
+        {"/anypath/*",null,"/redirected/regex/path"},
+        {"/anypath/*","params=true","/redirected/regex/path?params=true"}
     };
 
     @Test
     public void testDoFilter() throws Exception {
         RedirectFilter filter = new RedirectFilter();
         HttpServletResponse response = mock(HttpServletResponse.class);
-        ServletOutputStream out = mock(ServletOutputStream.class);
-        when(response.getOutputStream()).thenReturn(out);
-        FilterChain chain = mock(FilterChain.class);
 
+        FilterChain chain = mock(FilterChain.class);
+        RedirectConfigProcessor redirectConfigProcessor = mock(RedirectConfigProcessor.class);
+        Redirect redirect = mock(Redirect.class);
+        filter.redirect = redirectConfigProcessor;
+        when(filter.redirect.requestMatches(anyString(),anyString())).thenReturn(redirect);
+        when(redirect.getUrlSubstituted()).thenReturn(pathRedirectPairs[0][1]);
 
         //rinse & repeat this for each input/response pair
         HttpServletRequest request = mock(HttpServletRequest.class);
-        when(request.getRequestURL().thenReturn(new StringBuffer(inputRequests[0])));
+        when(request.getRequestURI()).thenReturn(inputResponsePairs[1][0]);//Gets path
+        when(request.getQueryString()).thenReturn(inputResponsePairs[1][1]);//Gets Query
 
         filter.doFilter(request, response,chain);
 
         verify(response).setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
-        verify(response).setHeader("Location", expectedResponses[0]);
+        verify(response).setHeader("Location", inputResponsePairs[1][2]);
     }
 }

--- a/servlets/src/test/java/com/meltmedia/cadmium/servlets/RedirectFilterTest.java
+++ b/servlets/src/test/java/com/meltmedia/cadmium/servlets/RedirectFilterTest.java
@@ -2,19 +2,44 @@ package com.meltmedia.cadmium.servlets;
 
 import org.junit.Test;
 
+import javax.servlet.FilterChain;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 
 public class RedirectFilterTest {
 
+    private String[] inputRequests = {
+        "http://domain.com/some/path/with?params=true",
+        "http://domain.com/some/path/without/",
+        "http://domain.com/some/path?extra=1"
+    };
+
+    private String[] expectedResponses = {
+        "http://domain.com/redirected/path?params=true",
+        "http://domain.com/redirected/path/with?params=true",
+        "http://domain.com/redirected/path/with?params=true&extra=1"
+    };
+
     @Test
     public void testDoFilter() throws Exception {
+        RedirectFilter filter = new RedirectFilter();
 
-        //If path = http://domain.com/some/path?params=true
-        //  redir should = http://domain.com/redirected/path?params=true
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        ServletOutputStream out = mock(ServletOutputStream.class);
+        when(response.getOutputStream()).thenReturn(out);
+        FilterChain chain = mock(FilterChain.class);
 
-        //If path = http://domain.com/some/path/without/params
-        //  redir should = http://domain.com/redirected/path/with?params=true
+        ServletRequest request; //add each inputRequest
 
-        //If path = http://domain.com/some/path?extra=1
-        //  redir should = http://domain.com/redirected/path/with?params=true&extra=1
+        filter.doFilter(request, response,chain);
+
+        verify(response).setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
+        verify(response).setHeader("Location", expectedResponses);
     }
 }

--- a/servlets/src/test/java/com/meltmedia/cadmium/servlets/RedirectFilterTest.java
+++ b/servlets/src/test/java/com/meltmedia/cadmium/servlets/RedirectFilterTest.java
@@ -1,0 +1,20 @@
+package com.meltmedia.cadmium.servlets;
+
+import org.junit.Test;
+
+
+public class RedirectFilterTest {
+
+    @Test
+    public void testDoFilter() throws Exception {
+
+        //If path = http://domain.com/some/path?params=true
+        //  redir should = http://domain.com/redirected/path?params=true
+
+        //If path = http://domain.com/some/path/without/params
+        //  redir should = http://domain.com/redirected/path/with?params=true
+
+        //If path = http://domain.com/some/path?extra=1
+        //  redir should = http://domain.com/redirected/path/with?params=true&extra=1
+    }
+}

--- a/servlets/src/test/java/com/meltmedia/cadmium/servlets/RedirectFilterTest.java
+++ b/servlets/src/test/java/com/meltmedia/cadmium/servlets/RedirectFilterTest.java
@@ -34,6 +34,8 @@ public class RedirectFilterTest {
         when(response.getOutputStream()).thenReturn(out);
         FilterChain chain = mock(FilterChain.class);
 
+
+        //rinse & repeat this for each input/response pair
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getRequestURL().thenReturn(new StringBuffer(inputRequests[0])));
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
   <artifactId>cadmium-war</artifactId>
   <packaging>war</packaging>


### PR DESCRIPTION
https://jira.meltdev.com/browse/RUI-1012

If the target of a cadmium redirect had query params they were taking over any query params set by the source. This takes the query params & concats them together. 

Duplicate params are not addressed, whoever handles the redirects should be aware of that. 