### PR TITLE
Remove Vault References

### DIFF
--- a/black-box-tests/src/test/resources/test-content-update/content-type.foo
+++ b/black-box-tests/src/test/resources/test-content-update/content-type.foo
@@ -26,7 +26,6 @@
     <a href="./email.html" title="Email">Email</a>
     <a href="./content-type.foo" title="Content Types">Content Types</a>
     <a href="./redirects.html" title="Redirects">Redirects</a>
-    <a href="./vault.html" title="Vault">Vault</a>
   </nav>
   <div id="content" class="clearfix">
     <section id="main">

--- a/black-box-tests/src/test/resources/test-content-update/email.html
+++ b/black-box-tests/src/test/resources/test-content-update/email.html
@@ -43,7 +43,6 @@
     <a href="./email.html" title="Email">Email</a>
     <a href="./content-type.foo" title="Content Types">Content Types</a>
     <a href="./redirects.html" title="Redirects">Redirects</a>
-    <a href="./vault.html" title="Vault">Vault</a>
   </nav>
   <div id="content" class="clearfix">
     <section id="main">

--- a/black-box-tests/src/test/resources/test-content-update/error-pages.html
+++ b/black-box-tests/src/test/resources/test-content-update/error-pages.html
@@ -43,7 +43,6 @@
     <a href="./email.html" title="Email">Email</a>
     <a href="./content-type.foo" title="Content Types">Content Types</a>
     <a href="./redirects.html" title="Redirects">Redirects</a>
-    <a href="./vault.html" title="Vault">Vault</a>
   </nav>
   <div id="content" class="clearfix">
     <section id="main">

--- a/black-box-tests/src/test/resources/test-content-update/hidden.html
+++ b/black-box-tests/src/test/resources/test-content-update/hidden.html
@@ -43,7 +43,6 @@
     <a href="./email.html" title="Email">Email</a>
     <a href="./content-type.foo" title="Content Types">Content Types</a>
     <a href="./redirects.html" title="Redirects">Redirects</a>
-    <a href="./vault.html" title="Vault">Vault</a>
   </nav>
   <div id="content" class="clearfix">
     <section id="main">

--- a/black-box-tests/src/test/resources/test-content-update/index.html
+++ b/black-box-tests/src/test/resources/test-content-update/index.html
@@ -43,7 +43,6 @@
     <a href="./email.html" title="Email">Email</a>
     <a href="./content-type.foo" title="Content Types">Content Types</a>
     <a href="./redirects.html" title="Redirects">Redirects</a>
-    <a href="./vault.html" title="Vault">Vault</a>
   </nav>
   <div id="content" class="clearfix">
     <section id="main">

--- a/black-box-tests/src/test/resources/test-content-update/redirects.html
+++ b/black-box-tests/src/test/resources/test-content-update/redirects.html
@@ -43,7 +43,6 @@
     <a href="./email.html" title="Email">Email</a>
     <a href="./content-type.foo" title="Content Types">Content Types</a>
     <a href="./redirects.html" title="Redirects">Redirects</a>
-    <a href="./vault.html" title="Vault">Vault</a>
   </nav>
   <div id="content" class="clearfix">
     <section id="main">

--- a/black-box-tests/src/test/resources/test-content-update/search.html
+++ b/black-box-tests/src/test/resources/test-content-update/search.html
@@ -43,7 +43,6 @@
     <a href="./email.html" title="Email">Email</a>
     <a href="./content-type.foo" title="Content Types">Content Types</a>
     <a href="./redirects.html" title="Redirects">Redirects</a>
-    <a href="./vault.html" title="Vault">Vault</a>
   </nav>
   <div id="content" class="clearfix">
     <section id="main">

--- a/black-box-tests/src/test/resources/test-content/content-type.foo
+++ b/black-box-tests/src/test/resources/test-content/content-type.foo
@@ -26,7 +26,6 @@
     <a href="./email.html" title="Email">Email</a>
     <a href="./content-type.foo" title="Content Types">Content Types</a>
     <a href="./redirects.html" title="Redirects">Redirects</a>
-    <a href="./vault.html" title="Vault">Vault</a>
   </nav>
   <div id="content" class="clearfix">
     <section id="main">

--- a/black-box-tests/src/test/resources/test-content/email.html
+++ b/black-box-tests/src/test/resources/test-content/email.html
@@ -26,7 +26,6 @@
     <a href="./email.html" title="Email">Email</a>
     <a href="./content-type.foo" title="Content Types">Content Types</a>
     <a href="./redirects.html" title="Redirects">Redirects</a>
-    <a href="./vault.html" title="Vault">Vault</a>
   </nav>
   <div id="content" class="clearfix">
     <section id="main">

--- a/black-box-tests/src/test/resources/test-content/error-pages.html
+++ b/black-box-tests/src/test/resources/test-content/error-pages.html
@@ -26,7 +26,6 @@
     <a href="./email.html" title="Email">Email</a>
     <a href="./content-type.foo" title="Content Types">Content Types</a>
     <a href="./redirects.html" title="Redirects">Redirects</a>
-    <a href="./vault.html" title="Vault">Vault</a>
   </nav>
   <div id="content" class="clearfix">
     <section id="main">

--- a/black-box-tests/src/test/resources/test-content/hidden.html
+++ b/black-box-tests/src/test/resources/test-content/hidden.html
@@ -26,7 +26,6 @@
     <a href="./email.html" title="Email">Email</a>
     <a href="./content-type.foo" title="Content Types">Content Types</a>
     <a href="./redirects.html" title="Redirects">Redirects</a>
-    <a href="./vault.html" title="Vault">Vault</a>
   </nav>
   <div id="content" class="clearfix">
     <section id="main">

--- a/black-box-tests/src/test/resources/test-content/index.html
+++ b/black-box-tests/src/test/resources/test-content/index.html
@@ -26,7 +26,6 @@
     <a href="./email.html" title="Email">Email</a>
     <a href="./content-type.foo" title="Content Types">Content Types</a>
     <a href="./redirects.html" title="Redirects">Redirects</a>
-    <a href="./vault.html" title="Vault">Vault</a>
   </nav>
   <div id="content" class="clearfix">
     <section id="main">

--- a/black-box-tests/src/test/resources/test-content/redirects.html
+++ b/black-box-tests/src/test/resources/test-content/redirects.html
@@ -26,7 +26,6 @@
     <a href="./email.html" title="Email">Email</a>
     <a href="./content-type.foo" title="Content Types">Content Types</a>
     <a href="./redirects.html" title="Redirects">Redirects</a>
-    <a href="./vault.html" title="Vault">Vault</a>
   </nav>
   <div id="content" class="clearfix">
     <section id="main">

--- a/black-box-tests/src/test/resources/test-content/search.html
+++ b/black-box-tests/src/test/resources/test-content/search.html
@@ -26,7 +26,6 @@
     <a href="./email.html" title="Email">Email</a>
     <a href="./content-type.foo" title="Content Types">Content Types</a>
     <a href="./redirects.html" title="Redirects">Redirects</a>
-    <a href="./vault.html" title="Vault">Vault</a>
   </nav>
   <div id="content" class="clearfix">
     <section id="main">

--- a/core/src/main/java/com/meltmedia/cadmium/core/config/impl/PropertiesWriterImpl.java
+++ b/core/src/main/java/com/meltmedia/cadmium/core/config/impl/PropertiesWriterImpl.java
@@ -51,7 +51,7 @@ public class PropertiesWriterImpl implements PropertiesWriter {
       } 
       catch(Exception e) {
 
-        log.warn("Failed to persist vault properties file.", e);
+        log.warn("Failed to persist properties file.", e);
       } 
       finally {
         IOUtils.closeQuietly(out);

--- a/search/src/test/resources/test-content/META-INF/not-indexed.html
+++ b/search/src/test/resources/test-content/META-INF/not-indexed.html
@@ -56,9 +56,6 @@
       </ul>
       <h2>Secondary Header</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam elit sem, convallis semper tincidunt a, molestie at leo. Nullam id rhoncus lorem. Maecenas placerat ante non dui euismod nec ultrices turpis malesuada. Nulla id risus ut nibh lacinia ultrices nec et nibh. Maecenas posuere tellus et urna pulvinar ultrices. Mauris in odio eget mauris aliquet blandit. Etiam sodales ultrices semper. Pellentesque aliquam sem at nunc dignissim pretium. Maecenas luctus sollicitudin sodales.</p>
-      <div data-vault-guid="9f40441e-40e9-4de2-b59a-7631d330dfa3">
-        Temporary vault content.
-      </div>
     </section>
     <section id="sidebar">
       <h3>Sidebar header</h3>

--- a/search/src/test/resources/test-content/index.html
+++ b/search/src/test/resources/test-content/index.html
@@ -56,9 +56,6 @@
       </ul>
       <h2>Secondary Header</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam elit sem, convallis semper tincidunt a, molestie at leo. Nullam id rhoncus lorem. Maecenas placerat ante non dui euismod nec ultrices turpis malesuada. Nulla id risus ut nibh lacinia ultrices nec et nibh. Maecenas posuere tellus et urna pulvinar ultrices. Mauris in odio eget mauris aliquet blandit. Etiam sodales ultrices semper. Pellentesque aliquam sem at nunc dignissim pretium. Maecenas luctus sollicitudin sodales.</p>
-      <div data-vault-guid="9f40441e-40e9-4de2-b59a-7631d330dfa3">
-        Temporary vault content.
-      </div>
     </section>
     <section id="sidebar">
       <h3>Sidebar header</h3>

--- a/search/src/test/resources/test-content/other.html
+++ b/search/src/test/resources/test-content/other.html
@@ -56,9 +56,6 @@
       </ul>
       <h2>Secondary Header</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam elit sem, convallis semper tincidunt a, molestie at leo. Nullam id rhoncus lorem. Maecenas placerat ante non dui euismod nec ultrices turpis malesuada. Nulla id risus ut nibh lacinia ultrices nec et nibh. Maecenas posuere tellus et urna pulvinar ultrices. Mauris in odio eget mauris aliquet blandit. Etiam sodales ultrices semper. Pellentesque aliquam sem at nunc dignissim pretium. Maecenas luctus sollicitudin sodales.</p>
-      <div data-vault-guid="9f40441e-40e9-4de2-b59a-7631d330dfa3">
-        Temporary vault content.
-      </div>
     </section>
     <section id="sidebar">
       <h3>Sidebar header</h3>

--- a/search/src/test/resources/test-content/subdir/index.html
+++ b/search/src/test/resources/test-content/subdir/index.html
@@ -56,9 +56,6 @@
       </ul>
       <h2>Secondary Header</h2>
       <p>Lorem ipsum dolor sit amet, consectetur meltmedia adipiscing elit. Aliquam elit sem, convallis semper tincidunt a, molestie at leo. Nullam id rhoncus lorem. Maecenas placerat ante non dui euismod nec ultrices turpis malesuada. Nulla id risus ut nibh lacinia ultrices nec et nibh. Maecenas posuere tellus et urna pulvinar ultrices. Mauris in odio eget mauris aliquet blandit. Etiam sodales ultrices semper. Pellentesque aliquam sem at nunc dignissim pretium. Maecenas luctus sollicitudin sodales.</p>
-      <div data-vault-guid="9f40441e-40e9-4de2-b59a-7631d330dfa3">
-        Temporary vault content.
-      </div>
     </section>
     <section id="sidebar">
       <h3>Sidebar header</h3>

--- a/search/src/test/resources/test-content/subdir/test2.htm
+++ b/search/src/test/resources/test-content/subdir/test2.htm
@@ -57,9 +57,6 @@
       </ul>
       <h2>Secondary Header</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam elit sem, convallis semper tincidunt a, molestie at leo. Nullam id rhoncus lorem. Maecenas placerat ante non dui euismod nec ultrices turpis malesuada. Nulla id risus ut nibh lacinia ultrices nec et nibh. Maecenas posuere tellus et urna pulvinar ultrices. Mauris in odio eget mauris aliquet blandit. Etiam sodales ultrices semper. Pellentesque aliquam sem at nunc dignissim pretium. Maecenas luctus sollicitudin sodales.</p>
-      <div data-vault-guid="9f40441e-40e9-4de2-b59a-7631d330dfa3">
-        Temporary vault content.
-      </div>
     </section>
     <section id="sidebar">
       <h3>Sidebar header</h3>

--- a/search/src/test/resources/test-content/subdir/test3.htm
+++ b/search/src/test/resources/test-content/subdir/test3.htm
@@ -57,9 +57,6 @@
       </ul>
       <h2>Secondary Header</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam elit sem, convallis semper tincidunt a, molestie at leo. Nullam id rhoncus lorem. Maecenas placerat ante non dui euismod nec ultrices turpis malesuada. Nulla id risus ut nibh lacinia ultrices nec et nibh. Maecenas posuere tellus et urna pulvinar ultrices. Mauris in odio eget mauris aliquet blandit. Etiam sodales ultrices semper. Pellentesque aliquam sem at nunc dignissim pretium. Maecenas luctus sollicitudin sodales.</p>
-      <div data-vault-guid="9f40441e-40e9-4de2-b59a-7631d330dfa3">
-        Temporary vault content.
-      </div>
     </section>
     <section id="sidebar">
       <h3>Sidebar header</h3>


### PR DESCRIPTION
### Overview
* Removed an error string that referenced the vault properties file. I'm pretty sure the `PropertiesWriterImpl.java` file wasn't vault specific, but assumed it was only writing a vault properties file. I made the error string more generic.
* Removed any `data-vault-guid` divs found. Most of them were found in the `black-box-tests` directory.
* Removed any hrefs to a `vault.html` file. The `vault.html` files don't even exist, but they were still linked, so I just removed them.

Aside from the error string the `PropertiesWriterImpl.java` file, I couldn't find any direct references to the vault library.