### PR TITLE
Hotfix GitHub auth fixes

### DIFF
--- a/captcha/pom.xml
+++ b/captcha/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>cadmium-captcha</artifactId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -35,6 +35,14 @@
                     <exclude>**/*</exclude>
                   </excludes>
                 </filter>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
               </filters>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-cli</artifactId>

--- a/copyright/pom.xml
+++ b/copyright/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>cadmium-copyright</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,7 +19,7 @@
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
-      <artifactId>org.eclipse.jgit</artifactId>
+      <artifactId>org.eclipse.jgit.java7</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-core</artifactId>

--- a/core/src/main/java/com/meltmedia/cadmium/core/git/GitService.java
+++ b/core/src/main/java/com/meltmedia/cadmium/core/git/GitService.java
@@ -27,13 +27,14 @@ import org.eclipse.jgit.api.CreateBranchCommand.SetupUpstreamMode;
 import org.eclipse.jgit.api.ListBranchCommand.ListMode;
 import org.eclipse.jgit.api.ResetCommand.ResetType;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTag;
 import org.eclipse.jgit.revwalk.RevWalk;
-import org.eclipse.jgit.storage.file.FileRepository;
+
 import org.eclipse.jgit.transport.SshSessionFactory;
 import org.eclipse.jgit.transport.TagOpt;
 import org.slf4j.Logger;
@@ -97,7 +98,7 @@ public class GitService
           && FileSystemManager.isDirector(repositoryDirectory) 
           && FileSystemManager.canRead(repositoryDirectory)
           && FileSystemManager.canWrite(repositoryDirectory)){
-        return new GitService(new FileRepository(repositoryDirectory));        
+        return new GitService(new FileRepository(repositoryDirectory));
       }
     }
     throw new Exception("Invalid git repo");
@@ -609,10 +610,10 @@ public class GitService
     } catch(Exception e) {
       log.debug("Fetch from origin failed.", e);
     }
-    List<RevTag> tags = git.tagList().call();
+    List<Ref> tags = git.tagList().call();
     if(tags != null && tags.size() > 0) {
-      for(RevTag tag : tags) {
-        if(tag.getTagName().equals(tagname)) {
+      for(Ref tag : tags) {
+        if(tag.getName().equals(tagname)) {
           throw new Exception("Tag already exists.");
         }
       }
@@ -621,7 +622,7 @@ public class GitService
     try{
       git.push().setPushTags().call();
     } catch(Exception e){
-      log.debug("Failed to push changes.", e);
+      log.error("Failed to push changes.", e);
     }
     return success;
   }
@@ -674,7 +675,7 @@ public class GitService
       } catch(Exception e) {
         log.warn("Invalid id: {}", repository.getFullBranch(), e);
       } finally {
-        revs.release();
+        revs.dispose();
       }
     }
     return repository.getBranch();

--- a/core/src/main/java/com/meltmedia/cadmium/core/github/ApiClient.java
+++ b/core/src/main/java/com/meltmedia/cadmium/core/github/ApiClient.java
@@ -19,6 +19,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.meltmedia.cadmium.core.AuthorizationApi;
 import com.meltmedia.cadmium.core.FileSystemManager;
+import com.meltmedia.cadmium.core.util.CadmiumHttpClientBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpMessage;
 import org.apache.http.HttpResponse;
@@ -28,10 +29,8 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.config.SocketConfig;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.eclipse.jgit.util.Base64;
 import org.slf4j.Logger;
@@ -94,23 +93,9 @@ public class ApiClient implements AuthorizationApi {
     }
     return cadmiumToken;
   }
-
-  protected HttpClient createHttpClient() {
-    HttpClient client = HttpClients.custom()
-        .setDefaultSocketConfig(SocketConfig.custom().setSoReuseAddress(true).build())
-        .build();
-    return client;
-  }
-
-  protected static HttpClient createStaticHttpClient() {
-    HttpClient client = HttpClients.custom()
-        .setDefaultSocketConfig(SocketConfig.custom().setSoReuseAddress(true).build())
-        .build();
-    return client;
-  }
   
   public static Authorization authorize(String username, String password, List<String> scopes, String note) throws Exception {
-    HttpClient client = createStaticHttpClient();
+    HttpClient client = CadmiumHttpClientBuilder.getCadmiumHttpClient();
     try {
       int limitRemain = getRateLimitRemain(null, client);
       if(limitRemain > 0) {
@@ -174,7 +159,7 @@ public class ApiClient implements AuthorizationApi {
   }
   
   public static List<Long> getAuthorizationIds(String username, String password) throws Exception {
-    HttpClient client = createStaticHttpClient();
+    HttpClient client = CadmiumHttpClientBuilder.getCadmiumHttpClient();
     List<Long> authIds = new ArrayList<Long>();
     try {
       int limitRemain = getRateLimitRemain(null, client);
@@ -228,7 +213,7 @@ public class ApiClient implements AuthorizationApi {
   public void deauthorizeToken(String username, String password, long authId) throws Exception {
     int limitRemain = getRateLimitRemain();
     if(limitRemain > 0) {
-      HttpClient client = createHttpClient();
+      HttpClient client = CadmiumHttpClientBuilder.getCadmiumHttpClient();
       
       HttpDelete delete = new HttpDelete("https://api.github.com/authorizations/"+authId);
       setupBasicAuth(username, password, delete);
@@ -262,7 +247,7 @@ public class ApiClient implements AuthorizationApi {
   public boolean isTeamMember(String teamId) throws Exception {
     int limitRemain = getRateLimitRemain();
     if(limitRemain > 0) {
-      HttpClient client = createHttpClient();
+      HttpClient client = CadmiumHttpClientBuilder.getCadmiumHttpClient();
       
       HttpGet get = new HttpGet("https://api.github.com/teams/"+teamId);
       addAuthHeader(get);
@@ -304,7 +289,7 @@ public class ApiClient implements AuthorizationApi {
     int limitRemain = getRateLimitRemain();
     
     if(limitRemain > 0) {
-      HttpClient client = createHttpClient();
+      HttpClient client = CadmiumHttpClientBuilder.getCadmiumHttpClient();
       
       HttpGet get = new HttpGet("https://api.github.com/user");
       addAuthHeader(get);
@@ -354,7 +339,7 @@ public class ApiClient implements AuthorizationApi {
   }
   
   public int getRateLimitRemain() throws Exception {
-    HttpClient client = createHttpClient();
+    HttpClient client = CadmiumHttpClientBuilder.getCadmiumHttpClient();
     try {
       return getRateLimitRemain(token, client);
     } finally {
@@ -410,7 +395,7 @@ public class ApiClient implements AuthorizationApi {
   }
 
   public String[] getAuthorizedOrgs() throws Exception {
-    HttpClient client = createHttpClient();
+    HttpClient client = CadmiumHttpClientBuilder.getCadmiumHttpClient();
 
     HttpGet get = new HttpGet("https://api.github.com/user/orgs");
     addAuthHeader(get);
@@ -447,7 +432,7 @@ public class ApiClient implements AuthorizationApi {
   }
 
   public Integer[] getAuthorizedTeamsInOrg(String org) throws Exception {
-    HttpClient client = createHttpClient();
+    HttpClient client = CadmiumHttpClientBuilder.getCadmiumHttpClient();
 
     HttpGet get = new HttpGet("https://api.github.com/orgs/"+org+"/teams");
     addAuthHeader(get);
@@ -487,7 +472,7 @@ public class ApiClient implements AuthorizationApi {
   public long commentOnCommit(String repoUri, String sha, String comment) throws Exception {
     String orgRepo = getOrgRepo(repoUri);
     
-    HttpClient client = createHttpClient();
+    HttpClient client = CadmiumHttpClientBuilder.getCadmiumHttpClient();
     
     HttpPost post = new HttpPost("https://api.github.com/repos/" + orgRepo + "/commits/" + sha + "/comments");
     addAuthHeader(post);

--- a/core/src/main/java/com/meltmedia/cadmium/core/github/ApiClient.java
+++ b/core/src/main/java/com/meltmedia/cadmium/core/github/ApiClient.java
@@ -39,11 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 public class ApiClient implements AuthorizationApi {
   private static final Logger log = LoggerFactory.getLogger(ApiClient.class);
@@ -126,6 +122,7 @@ public class ApiClient implements AuthorizationApi {
           body.scopes = scopes.toArray(new String[] {});
         }
         body.note = note;
+        body.fingerprint = UUID.randomUUID().toString();
         String bodySt = new Gson().toJson(body, AuthBody.class);
         log.trace("Loggin in with post body [{}]", bodySt);
         StringEntity postEntity = new StringEntity(bodySt);
@@ -578,6 +575,7 @@ public class ApiClient implements AuthorizationApi {
     @SuppressWarnings("unused")
     String scopes[];
     String note;
+    String fingerprint;
   }
   
   public static class Authorization {

--- a/core/src/main/java/com/meltmedia/cadmium/core/util/CadmiumHttpClientBuilder.java
+++ b/core/src/main/java/com/meltmedia/cadmium/core/util/CadmiumHttpClientBuilder.java
@@ -1,0 +1,29 @@
+package com.meltmedia.cadmium.core.util;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLContexts;
+import org.apache.http.impl.client.HttpClients;
+
+import javax.net.ssl.SSLContext;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+public class CadmiumHttpClientBuilder {
+
+  public static HttpClient getCadmiumHttpClient() throws KeyManagementException, NoSuchAlgorithmException {
+    SSLContext sslContext = SSLContexts.custom()
+        .useTLS()
+        .build();
+
+    SSLConnectionSocketFactory f = new SSLConnectionSocketFactory(
+        sslContext,
+        new String[]{"TLSv1", "TLSv1.1", "TLSv1.2"},
+        null,
+        new org.apache.http.conn.ssl.AllowAllHostnameVerifier());
+
+    return HttpClients.custom()
+        .setSSLSocketFactory(f)
+        .build();
+  }
+}

--- a/core/src/test/java/com/meltmedia/cadmium/core/util/CadmiumHttpClientBuilderTest.java
+++ b/core/src/test/java/com/meltmedia/cadmium/core/util/CadmiumHttpClientBuilderTest.java
@@ -1,0 +1,18 @@
+package com.meltmedia.cadmium.core.util;
+
+import org.apache.http.client.HttpClient;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+public class CadmiumHttpClientBuilderTest {
+
+
+  @Test
+  public void testCadmiumHttpClientBuilder() throws NoSuchAlgorithmException, KeyManagementException {
+    HttpClient httpClient = CadmiumHttpClientBuilder.getCadmiumHttpClient();
+    Assert.assertNotNull(httpClient);
+  }
+}

--- a/deployer/pom.xml
+++ b/deployer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>cadmium-deployer</artifactId>
   <packaging>war</packaging>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-deployment-parent</artifactId>

--- a/deployment/provisioning/pom.xml
+++ b/deployment/provisioning/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium-deployment-parent</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-deployment</artifactId>

--- a/email/pom.xml
+++ b/email/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>cadmium-email</artifactId>

--- a/executable-war/pom.xml
+++ b/executable-war/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-executable-war</artifactId>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <name>cadmium :: Maven</name>

--- a/pdf-concatenate/pom.xml
+++ b/pdf-concatenate/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-pdf-concatenate</artifactId>

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-persistence</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.meltmedia.cadmium</groupId>
   <artifactId>cadmium</artifactId>
-  <version>1.1.4-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>cadmium :: Parent POM</name>
@@ -89,7 +89,7 @@
       <dependency>
         <groupId>org.eclipse.jgit</groupId>
         <artifactId>org.eclipse.jgit</artifactId>
-        <version>1.3.0.201202151440-r</version>
+        <version>4.10.0.201712302008-r</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -85,11 +85,10 @@
         <version>${project.version}</version>
       </dependency>
 
-
       <dependency>
         <groupId>org.eclipse.jgit</groupId>
-        <artifactId>org.eclipse.jgit</artifactId>
-        <version>4.10.0.201712302008-r</version>
+        <artifactId>org.eclipse.jgit.java7</artifactId>
+        <version>3.7.1.201504261725-r</version>
       </dependency>
 
       <dependency>

--- a/search-suggest/pom.xml
+++ b/search-suggest/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-search-suggest</artifactId>

--- a/search/pom.xml
+++ b/search/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-search</artifactId>

--- a/servlets/pom.xml
+++ b/servlets/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>cadmium</artifactId>
     <groupId>com.meltmedia.cadmium</groupId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cadmium-servlets</artifactId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.meltmedia.cadmium</groupId>
     <artifactId>cadmium</artifactId>
-    <version>1.1.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>cadmium-war</artifactId>
   <packaging>war</packaging>


### PR DESCRIPTION
Added TLSv1.2 support for GitHub API calls. 
Updated to org.eclipse.jgit.java7
in response to
https://githubengineering.com/crypto-removal-notice/