### PR TITLE
Creates Exception for Invalid URLs passed to Redirect Filter

### DIFF
--- a/servlets/src/main/java/com/meltmedia/cadmium/servlets/InvalidURIException.java
+++ b/servlets/src/main/java/com/meltmedia/cadmium/servlets/InvalidURIException.java
@@ -1,0 +1,60 @@
+package com.meltmedia.cadmium.servlets;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Enumeration;
+
+/**
+ * This is the top level exception.
+ */
+public class InvalidURIException extends Exception
+{
+    /**
+     * Creates a new invalid uri exception with a message and a cause.
+     */
+    public InvalidURIException( String message, Throwable cause )
+    {
+        super( message, cause );
+    }
+
+    /**
+     * Creates a new invalid uri exception with just a message.
+     */
+    public InvalidURIException( String message )
+    {
+        super( message );
+    }
+
+    /**
+     * Creates a new invalid uri exception with just a cause.
+     */
+    public InvalidURIException( Throwable cause )
+    {
+        super( cause );
+    }
+
+    /**
+     * Formats an Exception message with request information
+     *
+     * @param message Message to start the exception.
+     * @param request request to get information from.
+     * @return
+     */
+    public static String getRequestInformationMessage(String message, HttpServletRequest request) {
+        StringBuilder sb = new StringBuilder(message).append('\n');
+        sb.append("Request Information - ").append('\n');
+        sb.append("Request URL: " + request.getRequestURL().toString()).append('\n');
+        sb.append("Request Method: " + request.getMethod()).append('\n');
+        sb.append("Request AuthType: " + request.getAuthType()).append('\n');
+
+        Enumeration<String> headerNames = request.getHeaderNames();
+
+        if (headerNames != null) {
+            sb.append("Request Headers - ").append('\n');
+            while (headerNames.hasMoreElements()) {
+                sb.append("Header: " + request.getHeader(headerNames.nextElement())).append('\n');
+            }
+        }
+
+        return sb.toString();
+    }
+}

--- a/servlets/src/main/java/com/meltmedia/cadmium/servlets/SecureRedirectFilter.java
+++ b/servlets/src/main/java/com/meltmedia/cadmium/servlets/SecureRedirectFilter.java
@@ -27,6 +27,8 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URI;
 
+import static com.meltmedia.cadmium.servlets.InvalidURIException.getRequestInformationMessage;
+
 /**
  * This filter will redirect requests that do not match the security options for a given page.
  * 
@@ -99,6 +101,9 @@ public class SecureRedirectFilter implements Filter {
       }
       HttpServletRequest request = (HttpServletRequest)req;
       HttpServletResponse response = (HttpServletResponse)resp;
+      if(!isValidURI(request.getRequestURL().toString())) {
+        throw new InvalidURIException(getRequestInformationMessage("Request URL not valid.", request));
+      }
       URI uri = URI.create(request.getRequestURL().toString());
 
       // For now, ignore the Jersey endpoints at /system and /api.
@@ -146,9 +151,28 @@ public class SecureRedirectFilter implements Filter {
     } catch (ServletException se) {
       log.trace("Failed in secure filter.", se);
       throw se;
+    } catch (InvalidURIException iue) {
+      log.trace("Failed in secure filter.", iue);
+      throw new ServletException(iue);
     } catch (Throwable t) {
       log.trace("Failed in secure filter.", t);
       throw new ServletException(t);
+    }
+  }
+
+  /* Returns true if URI is valid */
+  public static boolean isValidURI(String uriString)
+  {
+    /* Try creating a valid URI */
+    try {
+      URI.create(uriString);
+      return true;
+    }
+
+    // If there was an Exception
+    // while creating URI object
+    catch (Exception e) {
+      return false;
     }
   }
 

--- a/servlets/src/test/java/com/meltmedia/cadmium/servlets/SecureRedirectTest.java
+++ b/servlets/src/test/java/com/meltmedia/cadmium/servlets/SecureRedirectTest.java
@@ -15,8 +15,20 @@
  */
 package com.meltmedia.cadmium.servlets;
 
-import static org.mockito.Mockito.*;
+import com.meltmedia.cadmium.core.meta.SslRedirectConfigProcessor;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
@@ -25,21 +37,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-
-import com.meltmedia.cadmium.core.meta.SslRedirectConfigProcessor;
 import static com.meltmedia.cadmium.servlets.AbstractSecureRedirectStrategy.getDefaultPort;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests the SslRedirectFilter, making sure that it properly redirects users for both secure and insecure urls.
@@ -55,47 +54,68 @@ public class SecureRedirectTest {
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][] {
         // the filter must redirect pages when SSL termination is done by the container.
-        { simpleRequest("http://domain.com/secure.html"), TEXT_HTML, true, "https://domain.com/secure.html" },
-        { simpleRequest("http://domain.com/insecure.html"), TEXT_HTML, false, null },
-        { simpleRequest("https://domain.com/secure.html"), TEXT_HTML, false, null },
-        { simpleRequest("https://domain.com/insecure.html"), TEXT_HTML, true, "http://domain.com/insecure.html" },
-        { simpleRequest("http://domain.com:8080/secure.html"), TEXT_HTML, true, "https://domain.com:8443/secure.html" },
-        { simpleRequest("http://domain.com:8080/insecure.html"), TEXT_HTML, false, null },
-        { simpleRequest("https://domain.com:8433/secure.html"), TEXT_HTML, false, null },
-        { simpleRequest("https://domain.com:8443/insecure.html"), TEXT_HTML, true, "http://domain.com:8080/insecure.html" },
-        
+        { simpleRequest("http://domain.com/secure.html"), TEXT_HTML, true, "https://domain.com/secure.html" , NONE_THROWN },
+        { simpleRequest("http://domain.com/insecure.html"), TEXT_HTML, false, null , NONE_THROWN },
+        { simpleRequest("https://domain.com/secure.html"), TEXT_HTML, false, null , NONE_THROWN },
+        { simpleRequest("https://domain.com/insecure.html"), TEXT_HTML, true, "http://domain.com/insecure.html" , NONE_THROWN },
+        { simpleRequest("http://domain.com:8080/secure.html"), TEXT_HTML, true, "https://domain.com:8443/secure.html" , NONE_THROWN },
+        { simpleRequest("http://domain.com:8080/insecure.html"), TEXT_HTML, false, null , NONE_THROWN },
+        { simpleRequest("https://domain.com:8433/secure.html"), TEXT_HTML, false, null , NONE_THROWN },
+        { simpleRequest("https://domain.com:8443/insecure.html"), TEXT_HTML, true, "http://domain.com:8080/insecure.html" , NONE_THROWN },
+
         // missing files should not redirect.
-        { simpleRequest("https://domain.com/missing.html"), null, false, null },
-        { simpleRequest("https://domain.com/missing.html"), null, false, null },
-        { simpleRequest("https://domain.com:8080/missing.html"), null, false, null },
-        { simpleRequest("https://domain.com:8443/missing.html"), null, false, null },
-        
+        { simpleRequest("https://domain.com/missing.html"), null, false, null , NONE_THROWN },
+        { simpleRequest("https://domain.com/missing.html"), null, false, null , NONE_THROWN },
+        { simpleRequest("https://domain.com:8080/missing.html"), null, false, null , NONE_THROWN },
+        { simpleRequest("https://domain.com:8443/missing.html"), null, false, null , NONE_THROWN },
+
         // only html files should redirect.
-        { simpleRequest("http://domain.com/site.css"), TEXT_CSS, false, null },
-        { simpleRequest("https://domain.com/site.css"), TEXT_CSS, false, null },
-        
+        { simpleRequest("http://domain.com/site.css"), TEXT_CSS, false, null , NONE_THROWN },
+        { simpleRequest("https://domain.com/site.css"), TEXT_CSS, false, null , NONE_THROWN },
+
         // the content type test should work even if character set information is present.
-        { simpleRequest("http://domain.com/secure.html"), TEXT_HTML_UTF_8, true, "https://domain.com/secure.html" },
-        { simpleRequest("http://domain.com/insecure.html"), TEXT_HTML_UTF_8, false, null },
-        { simpleRequest("https://domain.com/secure.html"), TEXT_HTML_UTF_8, false, null },
-        { simpleRequest("https://domain.com/insecure.html"), TEXT_HTML_UTF_8, true, "http://domain.com/insecure.html" },        
+        { simpleRequest("http://domain.com/secure.html"), TEXT_HTML_UTF_8, true, "https://domain.com/secure.html" , NONE_THROWN },
+        { simpleRequest("http://domain.com/insecure.html"), TEXT_HTML_UTF_8, false, null , NONE_THROWN },
+        { simpleRequest("https://domain.com/secure.html"), TEXT_HTML_UTF_8, false, null , NONE_THROWN },
+        { simpleRequest("https://domain.com/insecure.html"), TEXT_HTML_UTF_8, true, "http://domain.com/insecure.html" , NONE_THROWN },
 
         // the filter must redirect pages when SSL termination is done by a load balancer.
-        { proxiedRequest("http", 80, "http://domain.com:8080/secure.html"), TEXT_HTML, true, "https://domain.com/secure.html" },
-        { proxiedRequest("http", 80, "http://domain.com:8080/insecure.html"), TEXT_HTML, false, null },
-        { proxiedRequest("https", 443, "http://domain.com:8080/secure.html"), TEXT_HTML, false, null },
-        { proxiedRequest("https", 443, "http://domain.com:8080/insecure.html"), TEXT_HTML, true, "http://domain.com/insecure.html" },
-        
+        { proxiedRequest("http", 80, "http://domain.com:8080/secure.html"), TEXT_HTML, true, "https://domain.com/secure.html" , NONE_THROWN },
+        { proxiedRequest("http", 80, "http://domain.com:8080/insecure.html"), TEXT_HTML, false, null , NONE_THROWN },
+        { proxiedRequest("https", 443, "http://domain.com:8080/secure.html"), TEXT_HTML, false, null , NONE_THROWN },
+        { proxiedRequest("https", 443, "http://domain.com:8080/insecure.html"), TEXT_HTML, true, "http://domain.com/insecure.html" , NONE_THROWN },
+
         // the filter must not effect things under /api or /service
-        { simpleRequest("https://domain.com:8443/api/service"), null, false, null },
-        { simpleRequest("http://domain.com:8080/api/service"), null, false, null },
-        { simpleRequest("https://domain.com:8443/system/service"), null, false, null },
-        { simpleRequest("http://domain.com:8080/system/service"), null, false, null },
-        { proxiedRequest("https", 443, "http://domain.com:8080/system/service"), null, false, null },
-        { proxiedRequest("http", 80, "http://domain.com:8080/system/service"), null, false, null },
-        { proxiedRequest("https", 443, "http://domain.com:8080/api/service"), null, false, null },
-        { proxiedRequest("http", 80, "http://domain.com:8080/api/service"), null, false, null }
+        { simpleRequest("https://domain.com:8443/api/service"), null, false, null , NONE_THROWN },
+        { simpleRequest("http://domain.com:8080/api/service"), null, false, null , NONE_THROWN },
+        { simpleRequest("https://domain.com:8443/system/service"), null, false, null , NONE_THROWN },
+        { simpleRequest("http://domain.com:8080/system/service"), null, false, null , NONE_THROWN },
+        { proxiedRequest("https", 443, "http://domain.com:8080/system/service"), null, false, null , NONE_THROWN },
+        { proxiedRequest("http", 80, "http://domain.com:8080/system/service"), null, false, null , NONE_THROWN },
+        { proxiedRequest("https", 443, "http://domain.com:8080/api/service"), null, false, null , NONE_THROWN },
+        { proxiedRequest("http", 80, "http://domain.com:8080/api/service"), null, false, null , NONE_THROWN },
+
+        // URLs with invalid URIs should not be filtered but should throw a special error
+        { invalidURIRequest("https", 80, "https://domain.com/secure.html?\"><script>alert(1)</script>=\""), null, false, null, INVALID_URL_EXCEPTION_THROWN }
     });
+  }
+
+  /**
+   * Creates a mock HttpServletRequest simulating SSL termination by the container. The URL does not have to be a valid URI, because of this you must provide all the other details
+   *
+   * @param requestProtocol http protocol for request.
+   * @param serverPort the server port for the request.
+   * @param requestUriString the request URL to mock.
+   * @return
+   */
+  public static HttpServletRequest invalidURIRequest(String requestProtocol, int serverPort, String requestUriString) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getHeader(anyString())).thenReturn(null);
+    when(request.getRequestURL()).thenReturn(new StringBuffer(requestUriString));
+    when(request.isSecure()).thenReturn("https".equals(requestProtocol));
+    when(request.getServerPort()).thenReturn(serverPort);
+    when(request.getProtocol()).thenReturn(requestProtocol);
+    return request;
   }
   
   /**
@@ -114,7 +134,7 @@ public class SecureRedirectTest {
     when(request.getProtocol()).thenReturn(requestUri.getScheme());
     return request;
   }
-  
+
   /**
    * Creates a mock HttpServletRequest simulating SSL termination by a load balancer, using X-Forwarded headers.
    * 
@@ -140,12 +160,14 @@ public class SecureRedirectTest {
   HttpServletRequest request;
   private boolean redirect;
   private String expectedLocation;
-  
-  public SecureRedirectTest( HttpServletRequest request, String contentType, boolean redirect, String expectedLocation ) {
+  private VerifyThrowable verifyThrowable;
+
+  public SecureRedirectTest( HttpServletRequest request, String contentType, boolean redirect, String expectedLocation, VerifyThrowable verifyThrowable ) {
     this.request = request;
     this.contentType = contentType;
     this.redirect = redirect;
     this.expectedLocation = expectedLocation;
+    this.verifyThrowable = verifyThrowable;
   }
   
   @SuppressWarnings("unchecked")
@@ -182,27 +204,36 @@ public class SecureRedirectTest {
    */
   @Test
   public void testRedirect() throws IOException, ServletException {
+
     HttpServletResponse response = mock(HttpServletResponse.class);
     ServletOutputStream out = mock(ServletOutputStream.class);
     when(response.getOutputStream()).thenReturn(out);
     FilterChain chain = mock(FilterChain.class);
-    
-    filter.doFilter(request, response, chain);
-    
-    if( redirect ) {
+
+    Exception thrown = null;
+
+    try {
+      filter.doFilter(request, response, chain);
+    } catch (Exception ex) {
+      thrown = ex;
+    }
+
+    if(thrown != null) {
+      verifyThrowable.verify(thrown);
+    } else if( redirect ) {
       // verify the status and the location header.
       verify(response).setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
       verify(response).setHeader("Location", expectedLocation);
       verify(out).flush();
       verify(out).close();
-      
+
       // verify that the chain was not called.
       verifyZeroInteractions(chain);
     }
     else {
       // verify that the response was not changed.
       verifyZeroInteractions(response);
-      
+
       // verify that the doFilter method was called.
       verify(chain).doFilter(request, response);
     }
@@ -218,4 +249,21 @@ public class SecureRedirectTest {
     }
     return map;
   }
+
+  public static interface VerifyThrowable {
+    public void verify(Throwable t);
+  }
+
+  public static final VerifyThrowable NONE_THROWN = new VerifyThrowable() {
+    public void verify( Throwable t ) {
+      Assert.fail("throwable not allowed "+t);
+    }
+  };
+
+  public static final VerifyThrowable INVALID_URL_EXCEPTION_THROWN = new VerifyThrowable() {
+    public void verify( Throwable t ) {
+      Assert.assertEquals(t.getCause().getClass(), InvalidURIException.class);
+    }
+  };
+
 }


### PR DESCRIPTION
SecureRedirectFilter validates URLs before attempting to filter them, failures throw an InvalidURLException.

This will be used to reduce noise in the #custom-lob-alerts room.

This has not been practically tested, only unit tested. I am currently not 100% sure how to deploy this.